### PR TITLE
resolve: make signature reflect impurity

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,9 @@
     "gulpfile.js",
     "package.json"
   ],
+  "dependencies": {
+    "purescript-eff": "^0.1.1"
+  },
   "devDependencies": {
     "purescript-assert": "^0.1.0"
   }

--- a/src/Node/Path.js
+++ b/src/Node/Path.js
@@ -10,9 +10,9 @@ exports.concat = function (segments) {
   return path.join.apply(this, segments);
 };
 
-exports.resolve = function (from) {
-  return function (to) {
-    return path.resolve.apply(this, from.concat([to]));
+exports.resolve = function (paths) {
+  return function () {
+    return path.resolve.apply(this, paths);
   };
 };
 

--- a/src/Node/Path.purs
+++ b/src/Node/Path.purs
@@ -1,5 +1,7 @@
 module Node.Path where
 
+import Control.Monad.Eff
+
 -- | Type for strings representing file paths.
 type FilePath = String
 
@@ -12,7 +14,7 @@ foreign import normalize :: FilePath -> FilePath
 foreign import concat :: Array FilePath -> FilePath
 
 -- | Resolves `to` to an absolute path ([from...], to).
-foreign import resolve :: Array FilePath -> FilePath -> FilePath
+foreign import resolve :: forall eff. Array FilePath -> Eff eff FilePath
 
 -- | Solve the relative path from `from` to `to`.
 foreign import relative :: FilePath -> FilePath -> FilePath

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -18,3 +18,6 @@ main = do
   assert $ extname "index" == ""
   assert $ sep == normalize "/"
   assert $ delimiter == ";" || delimiter == ":"
+  path1 <- resolve []
+  path2 <- resolve ["."]
+  assert $ path1 == path2


### PR DESCRIPTION
`resolve` will return different results depending on the current
working directory, so this should be captured in the type signature.

Also, simplify the arguments: zero arguments is the same as giving `"."`
as the only argument, so `from` and `to` can be collapsed into one
argument.
