### PR TITLE
chore: use node prefix imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Use node: prefix imports in FFI to preferentially force builtin module usage (#24)
 
 ## [v5.0.0](https://github.com/purescript-node/purescript-node-path/releases/tag/v5.0.0) - 2022-04-27
 

--- a/src/Node/Path.js
+++ b/src/Node/Path.js
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 export const normalize = path.normalize;
 
 export function concat(segments) {


### PR DESCRIPTION


**Description of the change**

change import to be prefixed with node: to indicate builtin module usage

see [Node Docs on Builtin Modules](https://nodejs.org/api/modules.html#built-in-modules) for reference. This change is live for all node versions >16, which is before current earliest LTS release of 18.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [ ] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
